### PR TITLE
Update TextRequest.cs to correct a datatype mismatch on the Type property/parameter.

### DIFF
--- a/invoicedapi/Entities/TextRequest.cs
+++ b/invoicedapi/Entities/TextRequest.cs
@@ -8,7 +8,7 @@ namespace Invoiced
 
         [JsonProperty("message")] public string Message { get; set; }
 
-        [JsonProperty("type")] public long? Type { get; set; }
+        [JsonProperty("type")] public string Type { get; set; }
 
         [JsonProperty("start")] public long? Start { get; set; }
 


### PR DESCRIPTION
Correct datatype mismatch. The API is expecting a string and not a nullable int64.