### PR TITLE
EntityList not returning correct URL values using convenience methods

### DIFF
--- a/invoicedapi/Entities/EntityList.cs
+++ b/invoicedapi/Entities/EntityList.cs
@@ -26,9 +26,9 @@ namespace Invoiced
         {
             var value = "";
 
-            if (LinkURLS == null) return value;
+            if (LinkURLS == null || !LinkURLS.ContainsKey(key)) return value;
 
-            LinkURLS.TryGetValue("self", out value);
+            LinkURLS.TryGetValue(key, out value);
             return value;
         }
     }


### PR DESCRIPTION
The GetURL method should honor the key parameter instead of always returning the hard coded "self" entry. This will correct the convenience method calls GetNextURL, GetSelfURL, GetLastURL.