### PR TITLE
Bug: ListAll crashes as it never pages

### DIFF
--- a/invoicedapi/Entities/AbstractEntity.cs
+++ b/invoicedapi/Entities/AbstractEntity.cs
@@ -207,13 +207,14 @@ namespace Invoiced
 
             if (!HasList()) throw new EntityException("List operation not supported on object.");
 
-            var tmpEntities = List(nextUrl, queryParams, customConverter);
-
             do
             {
+                var tmpEntities = List(nextUrl, queryParams, customConverter);
+                
                 if (entities == null)
                 {
                     entities = tmpEntities;
+                    entities.Capacity = tmpEntites.TotalCount;
                 }
                 else
                 {
@@ -221,6 +222,8 @@ namespace Invoiced
                     entities.LinkURLS = tmpEntities.LinkURLS;
                     entities.TotalCount = tmpEntities.TotalCount;
                 }
+                
+                nextUrl = entities.GetNextURL();
             } while (!string.IsNullOrEmpty(entities.GetNextURL()) && entities.GetSelfURL() != entities.GetLastURL());
 
             return entities;


### PR DESCRIPTION
ListAll was not calling the API to retrieve the next page of records. After the GetNextURL method is fixed, this method caused an out of memory exception.

Additionally, the list class works better when given a proper Capacity value. Otherwise, the base implementation will attempt to allocate arrays with exponential growth.