### PR TITLE
Fixes to support ListAll method of AbstractEntity class.

### DIFF
--- a/invoicedapi/Entities/AbstractEntity.cs
+++ b/invoicedapi/Entities/AbstractEntity.cs
@@ -207,8 +207,6 @@ namespace Invoiced
 
             if (!HasList()) throw new EntityException("List operation not supported on object.");
 
-            var tmpEntities = List(nextUrl, queryParams, customConverter);
-
             do
             {
                 var tmpEntities = List(nextUrl, queryParams, customConverter);

--- a/invoicedapi/Entities/AbstractEntity.cs
+++ b/invoicedapi/Entities/AbstractEntity.cs
@@ -159,7 +159,7 @@ namespace Invoiced
             _connection.Delete(GetEndpoint(true));
         }
 
-        private EntityList<T> List(string nextUrl, Dictionary<string, object> queryParams,
+        public EntityList<T> List(string nextUrl, Dictionary<string, object> queryParams,
             JsonConverter customConverter = null)
         {
             if (!HasList()) throw new EntityException("List operation not supported on object.");
@@ -211,9 +211,13 @@ namespace Invoiced
 
             do
             {
+                var tmpEntities = List(nextUrl, queryParams, customConverter);
+
                 if (entities == null)
                 {
                     entities = tmpEntities;
+                    if (tmpEntities.TotalCount > 0)
+                        entities.Capacity = tmpEntities.TotalCount;
                 }
                 else
                 {
@@ -221,6 +225,8 @@ namespace Invoiced
                     entities.LinkURLS = tmpEntities.LinkURLS;
                     entities.TotalCount = tmpEntities.TotalCount;
                 }
+
+                nextUrl = tmpEntities.GetNextURL();
             } while (!string.IsNullOrEmpty(entities.GetNextURL()) && entities.GetSelfURL() != entities.GetLastURL());
 
             return entities;

--- a/invoicedapi/Entities/Connection.cs
+++ b/invoicedapi/Entities/Connection.cs
@@ -1,14 +1,15 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using System.Linq;
 
 namespace Invoiced
 {
     public class Connection
     {
-        private static readonly string jsonAccept = "application/json";
+        private const string jsonAccept = "application/json";
         private readonly string _apikey;
 
         private HttpClient _client;
@@ -152,6 +153,14 @@ namespace Invoiced
             return new ListResponse(responseText, links, totalCount);
         }
 
+        internal void Delete(string url)
+        {
+            url = BaseUrl() + url;
+
+            var response = ExecuteRequest(HttpMethod.Delete, url, null);
+            ProcessResponse(response);
+        }
+
         /// <summary>
         /// Merges the given url with the Base Url of the connection environment.
         /// </summary>
@@ -217,14 +226,6 @@ namespace Invoiced
             return output;
         }
 
-        internal void Delete(string url)
-        {
-            url = BaseUrl() + url;
-
-            var response = ExecuteRequest(HttpMethod.Delete, url, null);
-            ProcessResponse(response);
-        }
-
         internal string BaseUrl()
         {
             if (_env == Environment.local)
@@ -249,12 +250,12 @@ namespace Invoiced
             return _client.SendAsync(request).ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
-        private string ProcessResponse(HttpResponseMessage response)
+        private static string ProcessResponse(HttpResponseMessage response)
         {
             if (response.StatusCode == HttpStatusCode.NoContent) return "";
             var responseText = response.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();
 
-            if (!response.IsSuccessStatusCode) throw HandleApiError((int) response.StatusCode, responseText);
+            if (!response.IsSuccessStatusCode) throw HandleApiError((int)response.StatusCode, responseText);
 
             return responseText;
         }
@@ -308,7 +309,7 @@ namespace Invoiced
             return builder.ToString();
         }
 
-        private InvoicedException HandleApiError(int responseCode, string responseBody)
+        private static InvoicedException HandleApiError(int responseCode, string responseBody)
         {
             if (responseCode == 401)
                 return new AuthException(responseBody);

--- a/invoicedapi/Entities/EntityList.cs
+++ b/invoicedapi/Entities/EntityList.cs
@@ -26,9 +26,9 @@ namespace Invoiced
         {
             var value = "";
 
-            if (LinkURLS == null) return value;
+            if (LinkURLS == null || !LinkURLS.ContainsKey(key)) return value;
 
-            LinkURLS.TryGetValue("self", out value);
+            LinkURLS.TryGetValue(key, out value);
             return value;
         }
     }


### PR DESCRIPTION
- The first issue is that the passed in url was not being parsed correctly for the GetList method of the Connection class.
- The second issue is that the ListAll method was not calling the API using the nextUrl value to get subsequent pages of data.
- The third issue in the ListAll method is that the Capacity property of the entities local variable should be set to minimize the number of allocations necessary when subsequent pages of data are appended to the final result.
- The fourth issue is that the EntityList class was not honoring the key URL to retrieve in the GetURL method. It was always returning the "self" link. This short-circuited the ListAll method to never attempt to retrieve secondary pages of data.

I changed the List method signature to public to enable users to fetch a single pages of data for local processing instead of forcing the client to hold onto all data in a List object. This allows the client to process a page and discard the downloaded data without creating memory pressure.