### PR TITLE
Fixes to support ListAll method of AbstractEntity class (also add Async methods)

### DIFF
--- a/invoicedapi/Entities/AbstractEntity.cs
+++ b/invoicedapi/Entities/AbstractEntity.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 
 namespace Invoiced
@@ -62,6 +63,261 @@ namespace Invoiced
         {
             _connection = conn;
         }
+
+        #region "Async Methods"
+
+        public virtual async System.Threading.Tasks.Task CreateAsync()
+        {
+            if (_entityCreated) throw new EntityException("Object has already been created.");
+
+            if (!HasCrud()) throw new EntityException("Create operation not supported on object.");
+
+            var url = GetEndpoint(false);
+            var entityJsonBody = ToJsonString();
+
+            var responseText = await _connection.PostAsync(url, null, entityJsonBody).ConfigureAwait(false);
+
+            try
+            {
+                JsonConvert.PopulateObject(responseText, this);
+            }
+            catch (Exception e)
+            {
+                throw new EntityException("", e);
+            }
+
+            _entityCreated = true;
+        }
+
+        public virtual async System.Threading.Tasks.Task SaveAllAsync()
+        {
+            if (!HasCrud()) throw new EntityException("Save operation not supported on object.");
+
+            var url = GetEndpoint(true);
+            var entityJsonBody = ToJsonString();
+            var responseText = await _connection.PatchAsync(url, entityJsonBody).ConfigureAwait(false);
+
+            try
+            {
+                JsonConvert.PopulateObject(responseText, this);
+            }
+            catch (Exception e)
+            {
+                throw new EntityException("", e);
+            }
+        }
+
+        public async System.Threading.Tasks.Task SaveAsync(string partialDataObject)
+        {
+            if (!HasCrud()) throw new EntityException("Save operation not supported on object.");
+
+            var url = GetEndpoint(true);
+            var responseText = await _connection.PatchAsync(url, partialDataObject).ConfigureAwait(false);
+
+            try
+            {
+                JsonConvert.PopulateObject(responseText, this);
+            }
+            catch (Exception e)
+            {
+                throw new EntityException("", e);
+            }
+        }
+
+        public Task<T> RetrieveAsync(long id)
+        {
+            return RetrieveAsync(id.ToString());
+        }
+
+        public async Task<T> RetrieveAsync(string id = null)
+        {
+            var url = GetEndpoint(false);
+
+            if (id != null) url += "/" + id;
+
+            var responseText = await _connection.GetAsync(url, null).ConfigureAwait(false);
+            T serializedObject;
+            try
+            {
+                serializedObject = JsonConvert.DeserializeObject<T>(responseText,
+                    new JsonSerializerSettings
+                    {
+                        NullValueHandling = NullValueHandling.Ignore,
+                        DefaultValueHandling = DefaultValueHandling.Ignore
+                    });
+                serializedObject._connection = _connection;
+            }
+            catch (Exception e)
+            {
+                throw new EntityException("", e);
+            }
+
+            return serializedObject;
+        }
+
+        public virtual async System.Threading.Tasks.Task DeleteAsync()
+        {
+            if (!HasCrud()) throw new EntityException("Delete operation not supported on object.");
+
+            await _connection.DeleteAsync(GetEndpoint(true)).ConfigureAwait(false);
+        }
+
+        public async Task<EntityList<T>> ListAsync(string nextUrl, Dictionary<string, object> queryParams,
+            JsonConverter customConverter = null)
+        {
+            if (!HasList()) throw new EntityException("List operation not supported on object.");
+
+            var url = GetEndpoint(false);
+
+            if (!string.IsNullOrEmpty(nextUrl)) url = nextUrl;
+
+            var response = await _connection.GetListAsync(url, queryParams).ConfigureAwait(false);
+
+            EntityList<T> entities;
+
+            var config = new JsonSerializerSettings
+            {
+                NullValueHandling = NullValueHandling.Ignore,
+                DefaultValueHandling = DefaultValueHandling.Ignore
+            };
+
+            try
+            {
+                if (customConverter != null) config.Converters.Add(customConverter);
+                entities = JsonConvert.DeserializeObject<EntityList<T>>(response.Result, config);
+
+                entities.LinkURLS = response.Links;
+                entities.TotalCount = response.TotalCount;
+            }
+            catch (Exception e)
+            {
+                throw new EntityException("", e);
+            }
+
+            foreach (var entity in entities) entity.ChangeConnection(_connection);
+
+            return entities;
+
+        }
+
+        public Task<EntityList<T>> ListAllAsync(Dictionary<string, object> queryParams, JsonConverter customConverter = null)
+        {
+            return ListAllAsync("", queryParams, customConverter);
+        }
+
+        public async Task<EntityList<T>> ListAllAsync(string nextUrl = "", Dictionary<string, object> queryParams = null,
+            JsonConverter customConverter = null)
+        {
+            EntityList<T> entities = null;
+
+            if (!HasList()) throw new EntityException("List operation not supported on object.");
+
+            do
+            {
+                var tmpEntities = await ListAsync(nextUrl, queryParams, customConverter).ConfigureAwait(false);
+
+                if (entities == null)
+                {
+                    entities = tmpEntities;
+                    if (tmpEntities.TotalCount > 0)
+                        entities.Capacity = tmpEntities.TotalCount;
+                }
+                else
+                {
+                    entities.AddRange(tmpEntities);
+                    entities.LinkURLS = tmpEntities.LinkURLS;
+                    entities.TotalCount = tmpEntities.TotalCount;
+                }
+
+                nextUrl = tmpEntities.GetNextURL();
+
+            } while (!string.IsNullOrEmpty(entities.GetNextURL()) && entities.GetSelfURL() != entities.GetLastURL());
+
+            return entities;
+        }
+
+        public async System.Threading.Tasks.Task VoidAsync()
+        {
+            if (!HasVoid()) throw new EntityException("Void operation not supported on object.");
+
+            var url = GetEndpoint(true) + "/void";
+
+            var responseText = await _connection.PostAsync(url, null, null).ConfigureAwait(false);
+
+            try
+            {
+                JsonConvert.PopulateObject(responseText, this);
+            }
+            catch (Exception e)
+            {
+                throw new EntityException("", e);
+            }
+        }
+
+        public async Task<IList<Attachment>> ListAttachmentsAsync()
+        {
+            if (!HasAttachments()) throw new EntityException("List attachments operation not supported on object.");
+
+            var url = GetEndpoint(true) + "/attachments";
+
+            var responseText = await _connection.GetAsync(url, null).ConfigureAwait(false);
+            return JsonConvert.DeserializeObject<IList<Attachment>>(responseText,
+                new JsonSerializerSettings
+                { NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.Ignore });
+        }
+
+        public async Task<IList<Email>> SendEmailAsync(EmailRequest emailRequest)
+        {
+            if (!HasSends()) throw new EntityException("Send email operation not supported on object.");
+
+            var url = GetEndpoint(true) + "/emails";
+
+            var jsonRequestBody = emailRequest.ToJsonString();
+
+            var responseText = await _connection.PostAsync(url, null, jsonRequestBody).ConfigureAwait(false);
+            return JsonConvert.DeserializeObject<IList<Email>>(responseText,
+                new JsonSerializerSettings
+                { NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.Ignore });
+        }
+
+        public async Task<Letter> SendLetterAsync(LetterRequest letterRequest = null)
+        {
+            if (!HasSends()) throw new EntityException("Send letter operation not supported on object.");
+
+            string responseText;
+
+            var url = GetEndpoint(true) + "/letters";
+
+            if (letterRequest != null)
+            {
+                var jsonRequestBody = letterRequest.ToJsonString();
+                responseText = await _connection.PostAsync(url, null, jsonRequestBody).ConfigureAwait(false);
+            }
+            else
+            {
+                responseText = _connection.Post(url, null, "");
+            }
+
+            return JsonConvert.DeserializeObject<Letter>(responseText,
+                new JsonSerializerSettings
+                { NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.Ignore });
+        }
+
+        public async Task<IList<TextMessage>> SendTextAsync(TextRequest textRequest)
+        {
+            if (!HasSends()) throw new EntityException("Send text message operation not supported on object.");
+
+            var url = GetEndpoint(true) + "/text_messages";
+
+            var jsonRequestBody = textRequest.ToJsonString();
+
+            var responseText = await _connection.PostAsync(url, null, jsonRequestBody).ConfigureAwait(false);
+            return JsonConvert.DeserializeObject<IList<TextMessage>>(responseText,
+                new JsonSerializerSettings
+                { NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.Ignore });
+        }
+
+        #endregion
 
         public virtual void Create()
         {
@@ -140,7 +396,8 @@ namespace Invoiced
                 serializedObject = JsonConvert.DeserializeObject<T>(responseText,
                     new JsonSerializerSettings
                     {
-                        NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.Ignore
+                        NullValueHandling = NullValueHandling.Ignore,
+                        DefaultValueHandling = DefaultValueHandling.Ignore
                     });
                 serializedObject._connection = _connection;
             }
@@ -174,7 +431,8 @@ namespace Invoiced
 
             var config = new JsonSerializerSettings
             {
-                NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.Ignore
+                NullValueHandling = NullValueHandling.Ignore,
+                DefaultValueHandling = DefaultValueHandling.Ignore
             };
 
             try
@@ -225,6 +483,7 @@ namespace Invoiced
                 }
 
                 nextUrl = tmpEntities.GetNextURL();
+
             } while (!string.IsNullOrEmpty(entities.GetNextURL()) && entities.GetSelfURL() != entities.GetLastURL());
 
             return entities;
@@ -232,11 +491,11 @@ namespace Invoiced
 
         protected string ToJsonString([CallerMemberName] string enclosingFunction = "")
         {
-            if (enclosingFunction != "") CurrentOperation = enclosingFunction;
+            if (!string.IsNullOrEmpty(enclosingFunction)) CurrentOperation = enclosingFunction;
 
             var output = JsonConvert.SerializeObject(this, Formatting.Indented,
                 new JsonSerializerSettings
-                    {NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.Ignore});
+                { NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.Ignore });
 
             CurrentOperation = null;
             return output;
@@ -269,7 +528,7 @@ namespace Invoiced
             var responseText = _connection.Get(url, null);
             return JsonConvert.DeserializeObject<IList<Attachment>>(responseText,
                 new JsonSerializerSettings
-                    {NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.Ignore});
+                { NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.Ignore });
         }
 
         public IList<Email> SendEmail(EmailRequest emailRequest)
@@ -283,14 +542,14 @@ namespace Invoiced
             var responseText = _connection.Post(url, null, jsonRequestBody);
             return JsonConvert.DeserializeObject<IList<Email>>(responseText,
                 new JsonSerializerSettings
-                    {NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.Ignore});
+                { NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.Ignore });
         }
 
         public Letter SendLetter(LetterRequest letterRequest = null)
         {
             if (!HasSends()) throw new EntityException("Send letter operation not supported on object.");
 
-            string responseText = null;
+            string responseText;
 
             var url = GetEndpoint(true) + "/letters";
 
@@ -306,7 +565,7 @@ namespace Invoiced
 
             return JsonConvert.DeserializeObject<Letter>(responseText,
                 new JsonSerializerSettings
-                    {NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.Ignore});
+                { NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.Ignore });
         }
 
         public IList<TextMessage> SendText(TextRequest textRequest)
@@ -320,7 +579,7 @@ namespace Invoiced
             var responseText = _connection.Post(url, null, jsonRequestBody);
             return JsonConvert.DeserializeObject<IList<TextMessage>>(responseText,
                 new JsonSerializerSettings
-                    {NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.Ignore});
+                { NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.Ignore });
         }
 
         protected abstract string EntityId();

--- a/invoicedapi/Entities/AbstractEntity.cs
+++ b/invoicedapi/Entities/AbstractEntity.cs
@@ -207,8 +207,6 @@ namespace Invoiced
 
             if (!HasList()) throw new EntityException("List operation not supported on object.");
 
-            var tmpEntities = List(nextUrl, queryParams, customConverter);
-
             do
             {
                 var tmpEntities = List(nextUrl, queryParams, customConverter);

--- a/invoicedapi/Entities/AbstractEntity.cs
+++ b/invoicedapi/Entities/AbstractEntity.cs
@@ -10,8 +10,23 @@ namespace Invoiced
     {
         private bool _entityCreated;
         private Connection _connection;
+        private string _CurrentOperation;
         // used to determine safe json serialisation. should always be null outside function bodies
-        protected string CurrentOperation;
+        protected string CurrentOperation
+        {
+            get
+            {
+                return _CurrentOperation;
+            }
+            set
+            {
+                if (value != null && value.EndsWith("Async"))
+                    _CurrentOperation = value.Substring(0, value.Length - 5);
+                else
+                    _CurrentOperation = value;
+                    
+            }
+        }
         private string _endpointBase = "";
         protected string EntityName;
 

--- a/invoicedapi/Entities/AbstractEntity.cs
+++ b/invoicedapi/Entities/AbstractEntity.cs
@@ -159,7 +159,7 @@ namespace Invoiced
             _connection.Delete(GetEndpoint(true));
         }
 
-        private EntityList<T> List(string nextUrl, Dictionary<string, object> queryParams,
+        public EntityList<T> List(string nextUrl, Dictionary<string, object> queryParams,
             JsonConverter customConverter = null)
         {
             if (!HasList()) throw new EntityException("List operation not supported on object.");
@@ -211,9 +211,13 @@ namespace Invoiced
 
             do
             {
+                var tmpEntities = List(nextUrl, queryParams, customConverter);
+
                 if (entities == null)
                 {
                     entities = tmpEntities;
+                    if (tmpEntities.TotalCount > 0)
+                        entities.Capacity = tmpEntities.TotalCount;
                 }
                 else
                 {
@@ -221,6 +225,8 @@ namespace Invoiced
                     entities.LinkURLS = tmpEntities.LinkURLS;
                     entities.TotalCount = tmpEntities.TotalCount;
                 }
+
+                nextUrl = tmpEntities.GetNextURL();
             } while (!string.IsNullOrEmpty(entities.GetNextURL()) && entities.GetSelfURL() != entities.GetLastURL());
 
             return entities;

--- a/invoicedapi/Entities/Connection.cs
+++ b/invoicedapi/Entities/Connection.cs
@@ -1,14 +1,15 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using System.Linq;
 
 namespace Invoiced
 {
     public class Connection
     {
-        private static readonly string jsonAccept = "application/json";
+        private const string jsonAccept = "application/json";
         private readonly string _apikey;
 
         private HttpClient _client;
@@ -152,6 +153,14 @@ namespace Invoiced
             return new ListResponse(responseText, links, totalCount);
         }
 
+        internal void Delete(string url)
+        {
+            url = BaseUrl() + url;
+
+            var response = ExecuteRequest(HttpMethod.Delete, url, null);
+            ProcessResponse(response);
+        }
+
         /// <summary>
         /// Merges the given url with the Base Url of the connection environment.
         /// </summary>
@@ -217,14 +226,6 @@ namespace Invoiced
             return output;
         }
 
-        internal void Delete(string url)
-        {
-            url = BaseUrl() + url;
-
-            var response = ExecuteRequest(HttpMethod.Delete, url, null);
-            ProcessResponse(response);
-        }
-
         internal string BaseUrl()
         {
             if (_env == Environment.local)
@@ -249,12 +250,12 @@ namespace Invoiced
             return _client.SendAsync(request).ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
-        private string ProcessResponse(HttpResponseMessage response)
+        private static string ProcessResponse(HttpResponseMessage response)
         {
             if (response.StatusCode == HttpStatusCode.NoContent) return "";
             var responseText = response.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();
 
-            if (!response.IsSuccessStatusCode) throw HandleApiError((int) response.StatusCode, responseText);
+            if (!response.IsSuccessStatusCode) throw HandleApiError((int)response.StatusCode, responseText);
 
             return responseText;
         }
@@ -308,7 +309,7 @@ namespace Invoiced
             return builder.ToString();
         }
 
-        private InvoicedException HandleApiError(int responseCode, string responseBody)
+        private static InvoicedException HandleApiError(int responseCode, string responseBody)
         {
             if (responseCode == 401)
                 return new AuthException(responseBody);

--- a/invoicedapi/Entities/EntityList.cs
+++ b/invoicedapi/Entities/EntityList.cs
@@ -26,9 +26,9 @@ namespace Invoiced
         {
             var value = "";
 
-            if (LinkURLS == null) return value;
+            if (LinkURLS == null || !LinkURLS.ContainsKey(key)) return value;
 
-            LinkURLS.TryGetValue("self", out value);
+            LinkURLS.TryGetValue(key, out value);
             return value;
         }
     }


### PR DESCRIPTION
- The first issue is that the passed in url was not being parsed correctly for the GetList method of the Connection class.
- The second issue is that the ListAll method was not calling the API using the nextUrl value to get subsequent pages of data.
- The third issue in the ListAll method is that the Capacity property of the entities local variable should be set to minimize the number of allocations necessary when subsequent pages of data are appended to the final result.
- The fourth issue is that the EntityList class was not honoring the key URL to retrieve in the GetURL method. It was always returning the "self" link. This short-circuited the ListAll method to never attempt to retrieve secondary pages of data.

I changed the List method signature to public to enable users to fetch a single pages of data for local processing instead of forcing the client to hold onto all data in a List object. This allows the client to process a page and discard the downloaded data without creating memory pressure.

To improve performance, I also added async methods for the operations.