### PR TITLE
Fix for Issue #19: ListAll() Throwing InvalidUri

### DIFF
--- a/invoicedapi.tests/Entities/ChargeTest.cs
+++ b/invoicedapi.tests/Entities/ChargeTest.cs
@@ -81,7 +81,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When(HttpMethod.Post, "https://testmode/charges")
+            mockHttp.When(HttpMethod.Post, "https://api.testmode.com/charges")
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();

--- a/invoicedapi.tests/Entities/ContactTest.cs
+++ b/invoicedapi.tests/Entities/ContactTest.cs
@@ -74,7 +74,7 @@ namespace InvoicedTest
         {
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When("https://testmode/customers/1234/contacts/30699")
+            mockHttp.When("https://api.testmode.com/customers/1234/contacts/30699")
                 .Respond("application/json", "{'id' : 30699, 'name' : 'Test McGee'}");
 
             var client = mockHttp.ToHttpClient();
@@ -123,7 +123,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When(HttpMethod.Post, "https://testmode/customers/1234/contacts").WithJson(jsonRequest)
+            mockHttp.When(HttpMethod.Post, "https://api.testmode.com/customers/1234/contacts").WithJson(jsonRequest)
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -172,7 +172,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
             var httpPatch = new HttpMethod("PATCH");
-            var request = mockHttp.When(httpPatch, "https://testmode/customers/1234/contacts/30699")
+            var request = mockHttp.When(httpPatch, "https://api.testmode.com/customers/1234/contacts/30699")
                 .WithJson(jsonRequest).Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -194,7 +194,7 @@ namespace InvoicedTest
         {
             var mockHttp = new MockHttpMessageHandler();
 
-            var request = mockHttp.When(HttpMethod.Delete, "https://testmode/customers/1234/contacts/30699")
+            var request = mockHttp.When(HttpMethod.Delete, "https://api.testmode.com/customers/1234/contacts/30699")
                 .Respond(HttpStatusCode.NoContent);
 
             var client = mockHttp.ToHttpClient();

--- a/invoicedapi.tests/Entities/CouponTest.cs
+++ b/invoicedapi.tests/Entities/CouponTest.cs
@@ -55,7 +55,7 @@ namespace InvoicedTest
         {
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When("https://testmode/coupons/alpha")
+            mockHttp.When("https://api.testmode.com/coupons/alpha")
                 .Respond("application/json", "{'id' : 'alpha', 'name' : 'Alpha'}");
 
             var client = mockHttp.ToHttpClient();
@@ -92,7 +92,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When(HttpMethod.Post, "https://testmode/coupons")
+            mockHttp.When(HttpMethod.Post, "https://api.testmode.com/coupons")
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -134,7 +134,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
             var httpPatch = new HttpMethod("PATCH");
-            var request = mockHttp.When(httpPatch, "https://testmode/coupons/alpha").WithJson(JsonRequest)
+            var request = mockHttp.When(httpPatch, "https://api.testmode.com/coupons/alpha").WithJson(JsonRequest)
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -154,7 +154,7 @@ namespace InvoicedTest
         {
             var mockHttp = new MockHttpMessageHandler();
 
-            var request = mockHttp.When(HttpMethod.Delete, "https://testmode/coupons/alpha")
+            var request = mockHttp.When(HttpMethod.Delete, "https://api.testmode.com/coupons/alpha")
                 .Respond(HttpStatusCode.NoContent);
 
             var client = mockHttp.ToHttpClient();
@@ -190,7 +190,7 @@ namespace InvoicedTest
             mockHeader["Link"] =
                 "<https://api.sandbox.invoiced.com/tax_rates?page=1>; rel=\"self\", <https://api.sandbox.invoiced.com/tax_rates?page=1>; rel=\"first\", <https://api.sandbox.invoiced.com/tax_rates?page=1>; rel=\"last\"";
 
-            var request = mockHttp.When(HttpMethod.Get, "https://testmode/coupons")
+            var request = mockHttp.When(HttpMethod.Get, "https://api.testmode.com/coupons")
                 .Respond(mockHeader, "application/json", jsonResponseListAll);
 
             var client = mockHttp.ToHttpClient();

--- a/invoicedapi.tests/Entities/CreditBalanceAdjustmentTest.cs
+++ b/invoicedapi.tests/Entities/CreditBalanceAdjustmentTest.cs
@@ -56,7 +56,7 @@ namespace InvoicedTest
         {
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When("https://testmode/credit_balance_adjustments/1234")
+            mockHttp.When("https://api.testmode.com/credit_balance_adjustments/1234")
                 .Respond("application/json", "{'id' : '1234', 'notes' : 'Test'}");
 
             var client = mockHttp.ToHttpClient();
@@ -90,7 +90,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When(HttpMethod.Post, "https://testmode/credit_balance_adjustments")
+            mockHttp.When(HttpMethod.Post, "https://api.testmode.com/credit_balance_adjustments")
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -126,7 +126,7 @@ namespace InvoicedTest
 
 	        var mockHttp = new MockHttpMessageHandler();
             var httpPatch = new HttpMethod("PATCH");
-            var request = mockHttp.When(httpPatch, "https://testmode/credit_balance_adjustments/1234")
+            var request = mockHttp.When(httpPatch, "https://api.testmode.com/credit_balance_adjustments/1234")
 	            .WithJson(jsonRequest)
                 .Respond("application/json", jsonResponse);
 
@@ -147,7 +147,7 @@ namespace InvoicedTest
         {
             var mockHttp = new MockHttpMessageHandler();
 
-            var request = mockHttp.When(HttpMethod.Delete, "https://testmode/credit_balance_adjustments/1234")
+            var request = mockHttp.When(HttpMethod.Delete, "https://api.testmode.com/credit_balance_adjustments/1234")
                 .Respond(HttpStatusCode.NoContent);
 
             var client = mockHttp.ToHttpClient();
@@ -179,7 +179,7 @@ namespace InvoicedTest
             mockHeader["Link"] =
                 "<https://api.sandbox.invoiced.com/credit_balance_adjustments?page=1>; rel=\"self\", <https://api.sandbox.invoiced.com/credit_balance_adjustments?page=1>; rel=\"first\", <https://api.sandbox.invoiced.com/credit_balance_adjustments?page=1>; rel=\"last\"";
 
-            var request = mockHttp.When(HttpMethod.Get, "https://testmode/credit_balance_adjustments")
+            var request = mockHttp.When(HttpMethod.Get, "https://api.testmode.com/credit_balance_adjustments")
                 .Respond(mockHeader, "application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();

--- a/invoicedapi.tests/Entities/CreditNoteTest.cs
+++ b/invoicedapi.tests/Entities/CreditNoteTest.cs
@@ -120,7 +120,7 @@ namespace InvoicedTest
         {
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When("https://testmode/credit_notes/4")
+            mockHttp.When("https://api.testmode.com/credit_notes/4")
                 .Respond("application/json", "{'id' : 4, 'number' : 'CN-0001'}");
 
             var client = mockHttp.ToHttpClient();
@@ -187,7 +187,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When(HttpMethod.Post, "https://testmode/credit_notes").Respond("application/json", jsonResponse);
+            mockHttp.When(HttpMethod.Post, "https://api.testmode.com/credit_notes").Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
 
@@ -253,7 +253,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
             var httpPatch = new HttpMethod("PATCH");
-            var request = mockHttp.When(httpPatch, "https://testmode/credit_notes/8441")
+            var request = mockHttp.When(httpPatch, "https://api.testmode.com/credit_notes/8441")
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -272,7 +272,7 @@ namespace InvoicedTest
         {
             var mockHttp = new MockHttpMessageHandler();
 
-            var request = mockHttp.When(HttpMethod.Delete, "https://testmode/credit_notes/8441")
+            var request = mockHttp.When(HttpMethod.Delete, "https://api.testmode.com/credit_notes/8441")
                 .Respond(HttpStatusCode.NoContent);
 
             var client = mockHttp.ToHttpClient();
@@ -338,7 +338,7 @@ namespace InvoicedTest
             mockHeader["Link"] =
                 "<https://api.sandbox.invoiced.com/credit_notes?page=1>; rel=\"self\", <https://api.sandbox.invoiced.com/credit_notes?page=1>; rel=\"first\", <https://api.sandbox.invoiced.com/credit_notes?page=1>; rel=\"last\"";
 
-            var request = mockHttp.When(HttpMethod.Get, "https://testmode/credit_notes")
+            var request = mockHttp.When(HttpMethod.Get, "https://api.testmode.com/credit_notes")
                 .Respond(mockHeader, "application/json", jsonResponseListAll);
 
             var client = mockHttp.ToHttpClient();

--- a/invoicedapi.tests/Entities/CustomerTest.cs
+++ b/invoicedapi.tests/Entities/CustomerTest.cs
@@ -77,7 +77,7 @@ namespace InvoicedTest
         {
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When("https://testmode/customers/4")
+            mockHttp.When("https://api.testmode.com/customers/4")
                 .Respond("application/json", "{'id' : 4, 'name' : 'Test McGee'}");
 
             var client = mockHttp.ToHttpClient();
@@ -149,7 +149,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When(HttpMethod.Post, "https://testmode/customers").WithJson(jsonRequest)
+            mockHttp.When(HttpMethod.Post, "https://api.testmode.com/customers").WithJson(jsonRequest)
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -221,7 +221,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
             var httpPatch = new HttpMethod("PATCH");
-            var request = mockHttp.When(httpPatch, "https://testmode/customers/1234").WithJson(JsonRequest)
+            var request = mockHttp.When(httpPatch, "https://api.testmode.com/customers/1234").WithJson(JsonRequest)
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -242,7 +242,7 @@ namespace InvoicedTest
         {
             var mockHttp = new MockHttpMessageHandler();
 
-            var request = mockHttp.When(HttpMethod.Delete, "https://testmode/customers/1234")
+            var request = mockHttp.When(HttpMethod.Delete, "https://api.testmode.com/customers/1234")
                 .Respond(HttpStatusCode.NoContent);
 
             var client = mockHttp.ToHttpClient();
@@ -295,7 +295,7 @@ namespace InvoicedTest
             mockHeader["Link"] =
                 "<https://api.sandbox.invoiced.com/customers?filter%5Bname%5D=Abraham+Lincoln&page=1>; rel=\"self\", <https://api.sandbox.invoiced.com/customers?filter%5Bname%5D=Abraham+Lincoln&page=1>; rel=\"first\", <https://api.sandbox.invoiced.com/customers?filter%5Bname%5D=Abraham+Lincoln&page=1>; rel=\"last\"";
 
-            var request = mockHttp.When(HttpMethod.Get, "https://testmode/customers")
+            var request = mockHttp.When(HttpMethod.Get, "https://api.testmode.com/customers")
                 .WithExactQueryString(filterByNameQ).Respond(mockHeader, "application/json", jsonResponseListAll);
 
             var client = mockHttp.ToHttpClient();
@@ -327,7 +327,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When(HttpMethod.Post, "https://testmode/notes").WithJson(jsonRequest)
+            mockHttp.When(HttpMethod.Post, "https://api.testmode.com/notes").WithJson(jsonRequest)
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -364,7 +364,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When(HttpMethod.Post, "https://testmode/customers/1234/contacts").WithJson(jsonRequest)
+            mockHttp.When(HttpMethod.Post, "https://api.testmode.com/customers/1234/contacts").WithJson(jsonRequest)
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -414,7 +414,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When(HttpMethod.Post, "https://testmode/customers/1234/line_items").WithJson(jsonRequest)
+            mockHttp.When(HttpMethod.Post, "https://api.testmode.com/customers/1234/line_items").WithJson(jsonRequest)
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -461,7 +461,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When(HttpMethod.Post, "https://testmode/tasks").WithJson(jsonRequest)
+            mockHttp.When(HttpMethod.Post, "https://api.testmode.com/tasks").WithJson(jsonRequest)
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -499,7 +499,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When(HttpMethod.Post, "https://testmode/customers/1234/emails")
+            mockHttp.When(HttpMethod.Post, "https://api.testmode.com/customers/1234/emails")
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -530,7 +530,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When(HttpMethod.Post, "https://testmode/customers/1234/letters")
+            mockHttp.When(HttpMethod.Post, "https://api.testmode.com/customers/1234/letters")
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -560,7 +560,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When(HttpMethod.Post, "https://testmode/customers/1234/text_messages")
+            mockHttp.When(HttpMethod.Post, "https://api.testmode.com/customers/1234/text_messages")
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -599,7 +599,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When(HttpMethod.Get, "https://testmode/customers/1234/balance")
+            mockHttp.When(HttpMethod.Get, "https://api.testmode.com/customers/1234/balance")
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -622,7 +622,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When(HttpMethod.Post, "https://testmode/customers/1234/consolidate_invoices")
+            mockHttp.When(HttpMethod.Post, "https://api.testmode.com/customers/1234/consolidate_invoices")
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();

--- a/invoicedapi.tests/Entities/EstimateTest.cs
+++ b/invoicedapi.tests/Entities/EstimateTest.cs
@@ -75,7 +75,7 @@ namespace InvoicedTest
         {
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When("https://testmode/estimates/4")
+            mockHttp.When("https://api.testmode.com/estimates/4")
                 .Respond("application/json", "{'id' : 4, 'number' : 'EST-0001'}");
 
             var client = mockHttp.ToHttpClient();
@@ -130,7 +130,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When(HttpMethod.Post, "https://testmode/estimates").Respond("application/json", jsonResponse);
+            mockHttp.When(HttpMethod.Post, "https://api.testmode.com/estimates").Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
 
@@ -183,7 +183,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
             var httpPatch = new HttpMethod("PATCH");
-            var request = mockHttp.When(httpPatch, "https://testmode/estimates/11658")
+            var request = mockHttp.When(httpPatch, "https://api.testmode.com/estimates/11658")
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -202,7 +202,7 @@ namespace InvoicedTest
         {
             var mockHttp = new MockHttpMessageHandler();
 
-            var request = mockHttp.When(HttpMethod.Delete, "https://testmode/estimates/11658")
+            var request = mockHttp.When(HttpMethod.Delete, "https://api.testmode.com/estimates/11658")
                 .Respond(HttpStatusCode.NoContent);
 
             var client = mockHttp.ToHttpClient();
@@ -256,7 +256,7 @@ namespace InvoicedTest
             mockHeader["Link"] =
                 "<https://api.sandbox.invoiced.com/estimates?page=1>; rel=\"self\", <https://api.sandbox.invoiced.com/estimates?page=1>; rel=\"first\", <https://api.sandbox.invoiced.com/estimates?page=1>; rel=\"last\"";
 
-            var request = mockHttp.When(HttpMethod.Get, "https://testmode/estimates")
+            var request = mockHttp.When(HttpMethod.Get, "https://api.testmode.com/estimates")
                 .Respond(mockHeader, "application/json", jsonResponseListAll);
 
             var client = mockHttp.ToHttpClient();
@@ -318,7 +318,7 @@ namespace InvoicedTest
 			}";
 
             var mockHttp = new MockHttpMessageHandler();
-            var request = mockHttp.When(HttpMethod.Post, "https://testmode/estimates/11658/invoice")
+            var request = mockHttp.When(HttpMethod.Post, "https://api.testmode.com/estimates/11658/invoice")
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();

--- a/invoicedapi.tests/Entities/EventTest.cs
+++ b/invoicedapi.tests/Entities/EventTest.cs
@@ -258,7 +258,7 @@ namespace InvoicedTest
             mockHeader["Link"] =
                 "<https://api.sandbox.invoiced.com/events?page=1>; rel=\"self\", <https://api.sandbox.invoiced.com/events?page=1>; rel=\"first\", <https://api.sandbox.invoiced.com/events?page=1>; rel=\"last\"";
 
-            var request = mockHttp.When(HttpMethod.Get, "https://testmode/events")
+            var request = mockHttp.When(HttpMethod.Get, "https://api.testmode.com/events")
                 .Respond(mockHeader, "application/json", jsonResponseListAll);
 
             var client = mockHttp.ToHttpClient();

--- a/invoicedapi.tests/Entities/InvoiceTest.cs
+++ b/invoicedapi.tests/Entities/InvoiceTest.cs
@@ -159,7 +159,7 @@ namespace InvoicedTest
         {
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When("https://testmode/invoices/4")
+            mockHttp.When("https://api.testmode.com/invoices/4")
                 .Respond("application/json", "{'id' : 4, 'number' : 'INV-0004'}");
 
             var client = mockHttp.ToHttpClient();
@@ -282,7 +282,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When(HttpMethod.Post, "https://testmode/invoices").Respond("application/json", jsonResponse);
+            mockHttp.When(HttpMethod.Post, "https://api.testmode.com/invoices").Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
 
@@ -403,7 +403,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
             var httpPatch = new HttpMethod("PATCH");
-            var request = mockHttp.When(httpPatch, "https://testmode/invoices/2334745")
+            var request = mockHttp.When(httpPatch, "https://api.testmode.com/invoices/2334745")
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -422,7 +422,7 @@ namespace InvoicedTest
         {
             var mockHttp = new MockHttpMessageHandler();
 
-            var request = mockHttp.When(HttpMethod.Delete, "https://testmode/invoices/2334745")
+            var request = mockHttp.When(HttpMethod.Delete, "https://api.testmode.com/invoices/2334745")
                 .Respond(HttpStatusCode.NoContent);
 
             var client = mockHttp.ToHttpClient();
@@ -548,7 +548,7 @@ namespace InvoicedTest
             mockHeader["Link"] =
                 "<https://api.sandbox.invoiced.com/invoices?filter%5Bname%5D=Abraham+Lincoln&page=1>; rel=\"self\", <https://api.sandbox.invoiced.com/invoices?filter%5Bname%5D=Abraham+Lincoln&page=1>; rel=\"first\", <https://api.sandbox.invoiced.com/invoices?filter%5Bname%5D=Abraham+Lincoln&page=1>; rel=\"last\"";
 
-            var request = mockHttp.When(HttpMethod.Get, "https://testmode/invoices").WithExactQueryString(filterByNameQ)
+            var request = mockHttp.When(HttpMethod.Get, "https://api.testmode.com/invoices").WithExactQueryString(filterByNameQ)
                 .Respond(mockHeader, "application/json", jsonResponseListAll);
 
             var client = mockHttp.ToHttpClient();
@@ -580,7 +580,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When(HttpMethod.Post, "https://testmode/notes").WithJson(jsonRequest)
+            mockHttp.When(HttpMethod.Post, "https://api.testmode.com/notes").WithJson(jsonRequest)
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -613,7 +613,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When(HttpMethod.Post, "https://testmode/invoices/2334745/letters")
+            mockHttp.When(HttpMethod.Post, "https://api.testmode.com/invoices/2334745/letters")
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -734,7 +734,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When(HttpMethod.Post, "https://testmode/invoices/2334745/pay")
+            mockHttp.When(HttpMethod.Post, "https://api.testmode.com/invoices/2334745/pay")
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -763,7 +763,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When(HttpMethod.Post, "https://testmode/invoices/2334745/payment_plan")
+            mockHttp.When(HttpMethod.Post, "https://api.testmode.com/invoices/2334745/payment_plan")
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -792,7 +792,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When(HttpMethod.Get, "https://testmode/invoices/2334745/payment_plan")
+            mockHttp.When(HttpMethod.Get, "https://api.testmode.com/invoices/2334745/payment_plan")
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -813,7 +813,7 @@ namespace InvoicedTest
         {
             var mockHttp = new MockHttpMessageHandler();
 
-            var request = mockHttp.When(HttpMethod.Delete, "https://testmode/invoices/2334745/payment_plan")
+            var request = mockHttp.When(HttpMethod.Delete, "https://api.testmode.com/invoices/2334745/payment_plan")
                 .Respond(HttpStatusCode.NoContent);
 
             var client = mockHttp.ToHttpClient();
@@ -842,7 +842,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
 
-            var request = mockHttp.When(HttpMethod.Get, "https://testmode/invoices/2334745/attachments")
+            var request = mockHttp.When(HttpMethod.Get, "https://api.testmode.com/invoices/2334745/attachments")
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -964,7 +964,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When(HttpMethod.Post, "https://testmode/invoices/2334745/void")
+            mockHttp.When(HttpMethod.Post, "https://api.testmode.com/invoices/2334745/void")
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();

--- a/invoicedapi.tests/Entities/ItemTest.cs
+++ b/invoicedapi.tests/Entities/ItemTest.cs
@@ -60,7 +60,7 @@ namespace InvoicedTest
         {
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When("https://testmode/items/alpha")
+            mockHttp.When("https://api.testmode.com/items/alpha")
                 .Respond("application/json", "{'id' : 'alpha', 'name' : 'Alpha'}");
 
             var client = mockHttp.ToHttpClient();
@@ -99,7 +99,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When(HttpMethod.Post, "https://testmode/items")
+            mockHttp.When(HttpMethod.Post, "https://api.testmode.com/items")
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -142,7 +142,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
             var httpPatch = new HttpMethod("PATCH");
-            var request = mockHttp.When(httpPatch, "https://testmode/items/alpha").WithJson(JsonRequest)
+            var request = mockHttp.When(httpPatch, "https://api.testmode.com/items/alpha").WithJson(JsonRequest)
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -162,7 +162,7 @@ namespace InvoicedTest
         {
             var mockHttp = new MockHttpMessageHandler();
 
-            var request = mockHttp.When(HttpMethod.Delete, "https://testmode/items/alpha")
+            var request = mockHttp.When(HttpMethod.Delete, "https://api.testmode.com/items/alpha")
                 .Respond(HttpStatusCode.NoContent);
 
             var client = mockHttp.ToHttpClient();
@@ -200,7 +200,7 @@ namespace InvoicedTest
             mockHeader["Link"] =
                 "<https://api.sandbox.invoiced.com/items?page=1>; rel=\"self\", <https://api.sandbox.invoiced.com/items?page=1>; rel=\"first\", <https://api.sandbox.invoiced.com/items?page=1>; rel=\"last\"";
 
-            var request = mockHttp.When(HttpMethod.Get, "https://testmode/items")
+            var request = mockHttp.When(HttpMethod.Get, "https://api.testmode.com/items")
                 .Respond(mockHeader, "application/json", jsonResponseListAll);
 
             var client = mockHttp.ToHttpClient();

--- a/invoicedapi.tests/Entities/NoteTest.cs
+++ b/invoicedapi.tests/Entities/NoteTest.cs
@@ -94,7 +94,7 @@ namespace InvoicedTest
             mockHeader["Link"] =
                 "<https://api.sandbox.invoiced.com/customers/1234/notes?page=1>; rel=\"self\", <https://api.sandbox.invoiced.com/customers/1234/notes?page=1>; rel=\"first\", <https://api.sandbox.invoiced.com/customers/1234/notes?page=1>; rel=\"last\"";
 
-            mockHttp.When(HttpMethod.Get, "https://testmode/customers/1234/notes").Respond(mockHeader,
+            mockHttp.When(HttpMethod.Get, "https://api.testmode.com/customers/1234/notes").Respond(mockHeader,
                 "application/json", "[{'id' : 1212, 'notes' : 'Test McGee'}]");
 
             var client = mockHttp.ToHttpClient();
@@ -122,7 +122,7 @@ namespace InvoicedTest
             mockHeader["Link"] =
                 "<https://api.sandbox.invoiced.com/invoices/56789/notes&page=1>; rel=\"self\", <https://api.sandbox.invoiced.com/invoices/56789/notes&page=1>; rel=\"first\", <https://api.sandbox.invoiced.com/invoices/56789/notes&page=1>; rel=\"last\"";
 
-            mockHttp.When(HttpMethod.Get, "https://testmode/invoices/56789/notes").Respond(mockHeader,
+            mockHttp.When(HttpMethod.Get, "https://api.testmode.com/invoices/56789/notes").Respond(mockHeader,
                 "application/json", "[{'id' : 2121, 'notes' : 'Test McGee'}]");
 
             var client = mockHttp.ToHttpClient();
@@ -162,7 +162,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When(HttpMethod.Post, "https://testmode/notes").Respond("application/json", jsonResponse);
+            mockHttp.When(HttpMethod.Post, "https://api.testmode.com/notes").Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
 
@@ -205,7 +205,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
             var httpPatch = new HttpMethod("PATCH");
-            var request = mockHttp.When(httpPatch, "https://testmode/notes/1212").WithJson(jsonRequest)
+            var request = mockHttp.When(httpPatch, "https://api.testmode.com/notes/1212").WithJson(jsonRequest)
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -227,7 +227,7 @@ namespace InvoicedTest
         {
             var mockHttp = new MockHttpMessageHandler();
 
-            var request = mockHttp.When(HttpMethod.Delete, "https://testmode/notes/1212")
+            var request = mockHttp.When(HttpMethod.Delete, "https://api.testmode.com/notes/1212")
                 .Respond(HttpStatusCode.NoContent);
 
             var client = mockHttp.ToHttpClient();

--- a/invoicedapi.tests/Entities/PaymentSourceTest.cs
+++ b/invoicedapi.tests/Entities/PaymentSourceTest.cs
@@ -32,7 +32,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When(HttpMethod.Post, "https://testmode/customers/1234/payment_sources")
+            mockHttp.When(HttpMethod.Post, "https://api.testmode.com/customers/1234/payment_sources")
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -55,7 +55,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When(HttpMethod.Post, "https://testmode/customers/1234/payment_sources")
+            mockHttp.When(HttpMethod.Post, "https://api.testmode.com/customers/1234/payment_sources")
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -85,7 +85,7 @@ namespace InvoicedTest
                     "<https://api.sandbox.invoiced.com/customers/1234/payment_sources?page=1>; rel=\"self\", <https://api.sandbox.invoiced.com/customers/1234/payment_sources?page=1>; rel=\"first\", <https://api.sandbox.invoiced.com/customers/1234/payment_sources?page=1>; rel=\"last\""
             };
 
-            mockHttp.When(HttpMethod.Get, "https://testmode/customers/1234/payment_sources")
+            mockHttp.When(HttpMethod.Get, "https://api.testmode.com/customers/1234/payment_sources")
                 .Respond(mockHeader, "application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();

--- a/invoicedapi.tests/Entities/PaymentTest.cs
+++ b/invoicedapi.tests/Entities/PaymentTest.cs
@@ -78,7 +78,7 @@ namespace InvoicedTest
         {
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When("https://testmode/payments/656093")
+            mockHttp.When("https://api.testmode.com/payments/656093")
                 .Respond("application/json", "{'id' : 656093, 'currency': 'usd'}");
 
             var client = mockHttp.ToHttpClient();
@@ -138,7 +138,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When(HttpMethod.Post, "https://testmode/payments")
+            mockHttp.When(HttpMethod.Post, "https://api.testmode.com/payments")
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -207,7 +207,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
             var httpPatch = new HttpMethod("PATCH");
-            var request = mockHttp.When(httpPatch, "https://testmode/payments/656093").WithJson(JsonRequest)
+            var request = mockHttp.When(httpPatch, "https://api.testmode.com/payments/656093").WithJson(JsonRequest)
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -246,7 +246,7 @@ namespace InvoicedTest
 	            'voided': true
 	        }";
 
-            var request = mockHttp.When(HttpMethod.Delete, "https://testmode/payments/656093")
+            var request = mockHttp.When(HttpMethod.Delete, "https://api.testmode.com/payments/656093")
 		            .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -304,7 +304,7 @@ namespace InvoicedTest
             mockHeader["Link"] =
                 "<https://api.sandbox.invoiced.com/payments?page=1>; rel=\"self\", <https://api.sandbox.invoiced.com/payments?page=1>; rel=\"first\", <https://api.sandbox.invoiced.com/payments?page=1>; rel=\"last\"";
 
-            var request = mockHttp.When(HttpMethod.Get, "https://testmode/payments")
+            var request = mockHttp.When(HttpMethod.Get, "https://api.testmode.com/payments")
                 .Respond(mockHeader, "application/json", jsonResponseListAll);
 
             var client = mockHttp.ToHttpClient();

--- a/invoicedapi.tests/Entities/PlanTest.cs
+++ b/invoicedapi.tests/Entities/PlanTest.cs
@@ -58,7 +58,7 @@ namespace InvoicedTest
         {
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When("https://testmode/plans/alpha")
+            mockHttp.When("https://api.testmode.com/plans/alpha")
                 .Respond("application/json", "{'id' : 'alpha', 'name' : 'Alpha'}");
 
             var client = mockHttp.ToHttpClient();
@@ -98,7 +98,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When(HttpMethod.Post, "https://testmode/plans")
+            mockHttp.When(HttpMethod.Post, "https://api.testmode.com/plans")
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -143,7 +143,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
             var httpPatch = new HttpMethod("PATCH");
-            var request = mockHttp.When(httpPatch, "https://testmode/plans/alpha").WithJson(JsonRequest)
+            var request = mockHttp.When(httpPatch, "https://api.testmode.com/plans/alpha").WithJson(JsonRequest)
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -163,7 +163,7 @@ namespace InvoicedTest
         {
             var mockHttp = new MockHttpMessageHandler();
 
-            var request = mockHttp.When(HttpMethod.Delete, "https://testmode/plans/alpha")
+            var request = mockHttp.When(HttpMethod.Delete, "https://api.testmode.com/plans/alpha")
                 .Respond(HttpStatusCode.NoContent);
 
             var client = mockHttp.ToHttpClient();
@@ -202,7 +202,7 @@ namespace InvoicedTest
             mockHeader["Link"] =
                 "<https://api.sandbox.invoiced.com/plans?page=1>; rel=\"self\", <https://api.sandbox.invoiced.com/plans?page=1>; rel=\"first\", <https://api.sandbox.invoiced.com/plans?page=1>; rel=\"last\"";
 
-            var request = mockHttp.When(HttpMethod.Get, "https://testmode/plans")
+            var request = mockHttp.When(HttpMethod.Get, "https://api.testmode.com/plans")
                 .Respond(mockHeader, "application/json", jsonResponseListAll);
 
             var client = mockHttp.ToHttpClient();

--- a/invoicedapi.tests/Entities/RefundTest.cs
+++ b/invoicedapi.tests/Entities/RefundTest.cs
@@ -26,7 +26,7 @@ namespace InvoicedTest
 			}";
 
             var mockHttp = new MockHttpMessageHandler();
-            var request = mockHttp.When(HttpMethod.Post, "https://testmode/charges/46374/refunds")
+            var request = mockHttp.When(HttpMethod.Post, "https://api.testmode.com/charges/46374/refunds")
                 .WithJson(jsonRequest)
                 .Respond("application/json", jsonResponse);
 

--- a/invoicedapi.tests/Entities/SubscriptionTest.cs
+++ b/invoicedapi.tests/Entities/SubscriptionTest.cs
@@ -87,7 +87,7 @@ namespace InvoicedTest
         {
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When("https://testmode/subscriptions/13117")
+            mockHttp.When("https://api.testmode.com/subscriptions/13117")
                 .Respond("application/json", "{'id' : 13117, 'cycles': 1}");
 
             var client = mockHttp.ToHttpClient();
@@ -146,7 +146,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When(HttpMethod.Post, "https://testmode/subscriptions")
+            mockHttp.When(HttpMethod.Post, "https://api.testmode.com/subscriptions")
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -210,7 +210,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
             var httpPatch = new HttpMethod("PATCH");
-            var request = mockHttp.When(httpPatch, "https://testmode/subscriptions/13117").WithJson(JsonRequest)
+            var request = mockHttp.When(httpPatch, "https://api.testmode.com/subscriptions/13117").WithJson(JsonRequest)
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -230,7 +230,7 @@ namespace InvoicedTest
         {
             var mockHttp = new MockHttpMessageHandler();
 
-            var request = mockHttp.When(HttpMethod.Delete, "https://testmode/subscriptions/13117")
+            var request = mockHttp.When(HttpMethod.Delete, "https://api.testmode.com/subscriptions/13117")
                 .Respond(HttpStatusCode.NoContent);
 
             var client = mockHttp.ToHttpClient();
@@ -245,7 +245,7 @@ namespace InvoicedTest
         {
             var mockHttp = new MockHttpMessageHandler();
 
-            var request = mockHttp.When(HttpMethod.Delete, "https://testmode/subscriptions/13117")
+            var request = mockHttp.When(HttpMethod.Delete, "https://api.testmode.com/subscriptions/13117")
                 .Respond(HttpStatusCode.NoContent);
 
             var client = mockHttp.ToHttpClient();
@@ -303,7 +303,7 @@ namespace InvoicedTest
             mockHeader["Link"] =
                 "<https://api.sandbox.invoiced.com/subscriptions?page=1>; rel=\"self\", <https://api.sandbox.invoiced.com/subscriptions?page=1>; rel=\"first\", <https://api.sandbox.invoiced.com/subscriptions?page=1>; rel=\"last\"";
 
-            var request = mockHttp.When(HttpMethod.Get, "https://testmode/subscriptions")
+            var request = mockHttp.When(HttpMethod.Get, "https://api.testmode.com/subscriptions")
                 .Respond(mockHeader, "application/json", jsonResponseListAll);
 
             var client = mockHttp.ToHttpClient();
@@ -386,7 +386,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When(HttpMethod.Post, "https://testmode/subscriptions/preview")
+            mockHttp.When(HttpMethod.Post, "https://api.testmode.com/subscriptions/preview")
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();

--- a/invoicedapi.tests/Entities/TaxRateTest.cs
+++ b/invoicedapi.tests/Entities/TaxRateTest.cs
@@ -52,7 +52,7 @@ namespace InvoicedTest
         {
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When("https://testmode/tax_rates/alpha")
+            mockHttp.When("https://api.testmode.com/tax_rates/alpha")
                 .Respond("application/json", "{'id' : 'alpha', 'name' : 'Alpha'}");
 
             var client = mockHttp.ToHttpClient();
@@ -86,7 +86,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
 
-            mockHttp.When(HttpMethod.Post, "https://testmode/tax_rates")
+            mockHttp.When(HttpMethod.Post, "https://api.testmode.com/tax_rates")
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -125,7 +125,7 @@ namespace InvoicedTest
 
             var mockHttp = new MockHttpMessageHandler();
             var httpPatch = new HttpMethod("PATCH");
-            var request = mockHttp.When(httpPatch, "https://testmode/tax_rates/alpha").WithJson(JsonRequest)
+            var request = mockHttp.When(httpPatch, "https://api.testmode.com/tax_rates/alpha").WithJson(JsonRequest)
                 .Respond("application/json", jsonResponse);
 
             var client = mockHttp.ToHttpClient();
@@ -145,7 +145,7 @@ namespace InvoicedTest
         {
             var mockHttp = new MockHttpMessageHandler();
 
-            var request = mockHttp.When(HttpMethod.Delete, "https://testmode/tax_rates/alpha")
+            var request = mockHttp.When(HttpMethod.Delete, "https://api.testmode.com/tax_rates/alpha")
                 .Respond(HttpStatusCode.NoContent);
 
             var client = mockHttp.ToHttpClient();
@@ -178,7 +178,7 @@ namespace InvoicedTest
             mockHeader["Link"] =
                 "<https://api.sandbox.invoiced.com/tax_rates?page=1>; rel=\"self\", <https://api.sandbox.invoiced.com/tax_rates?page=1>; rel=\"first\", <https://api.sandbox.invoiced.com/tax_rates?page=1>; rel=\"last\"";
 
-            var request = mockHttp.When(HttpMethod.Get, "https://testmode/tax_rates")
+            var request = mockHttp.When(HttpMethod.Get, "https://api.testmode.com/tax_rates")
                 .Respond(mockHeader, "application/json", jsonResponseListAll);
 
             var client = mockHttp.ToHttpClient();

--- a/invoicedapi/Contents/ConnectionUrl.cs
+++ b/invoicedapi/Contents/ConnectionUrl.cs
@@ -13,6 +13,6 @@ namespace Invoiced
         public const string invoicedProduction = "https://api.invoiced.com";
         public const string invoicedSandbox = "https://api.sandbox.invoiced.com";
         public const string invoicedLocal = "https://localhost:8080";
-        public const string invoicedTest = "https://testmode";
+        public const string invoicedTest = "https://api.testmode.com";
     }
 }

--- a/invoicedapi/Entities/Connection.cs
+++ b/invoicedapi/Entities/Connection.cs
@@ -135,6 +135,10 @@ namespace Invoiced
 
         internal ListResponse GetList(string url, Dictionary<string, object> queryParams)
         {
+            if (!Uri.IsWellFormedUriString(url, UriKind.Absolute))
+            {
+                url = BaseUrl() + url;
+            }
             var uri = AddQueryParamsToUri(url, queryParams);
             var response = ExecuteRequest(HttpMethod.Get, uri, null);
             var responseText = ProcessResponse(response);


### PR DESCRIPTION
Fix for: https://github.com/Invoiced/invoiced-dotnet/issues/19

Changes: test connection uri changed to a well-formed absolute uri to match expectations.  Tests updated to use new test uri.  Connection object now prefixes with base url if url passed is not absolute and well-formed. 

Testing: All existing tests now pass.
